### PR TITLE
User quests

### DIFF
--- a/api/__init__.py
+++ b/api/__init__.py
@@ -7,7 +7,6 @@ from config import config
 
 db = SQLAlchemy()
 
-
 class ExtendedAPI(Api):
     """
     credit to https://stackoverflow.com/a/57921890
@@ -79,7 +78,9 @@ def create_app(config_name='default'):
         }), 404
 
     from api.resources.users import UserResource
+    from api.resources.user_quests import UserQuestsResource
 
     api.add_resource(UserResource, '/api/v1/users')
+    api.add_resource(UserQuestsResource, '/api/v1/users/<int:user_id>/quests')
 
     return app

--- a/api/database/models.py
+++ b/api/database/models.py
@@ -112,7 +112,6 @@ class Quest(db.Model):
         self.level = level
 
 
-
 class UserQuest(db.Model):
     """
     UserQuest Model

--- a/api/database/models.py
+++ b/api/database/models.py
@@ -3,7 +3,6 @@ from sqlalchemy import Column, String, Integer, Boolean, DateTime, ForeignKey
 from datetime import datetime
 from api import db
 
-
 class User(db.Model):
     """
     User Model
@@ -111,7 +110,6 @@ class Quest(db.Model):
         self.type = type
         self.level = level
 
-
 class UserQuest(db.Model):
     """
     UserQuest Model
@@ -137,12 +135,10 @@ class UserQuest(db.Model):
     quests = db.relationship('Quest', backref='quest')
 
     def __init__(self, quest_id, user_id, completion_status, progress):
-
         self.quest_id = quest_id
         self.user_id = user_id
         self.completion_status = completion_status
         self.progress = progress
-
 
     def update(self):
         """
@@ -182,14 +178,12 @@ class Encounter(db.Model):
         self.quest_id = quest_id
         self.progress = progress
 
-
     def update(self):
         """
         updates a new model into a database
         the model must exist in the database
         """
         db.session.commit()
-
 
 class Action(db.Model):
     """
@@ -213,7 +207,6 @@ class Action(db.Model):
             description = bleach.clean(description).strip()
             if description == '':
                 description = None
-
 
         self.description = description
         self.encounter_id = encounter_id

--- a/api/resources/user_quests.py
+++ b/api/resources/user_quests.py
@@ -45,10 +45,10 @@ class UserQuestsResource(Resource):
 
     def get(self, *args, **kwargs):
         user_id = request.view_args['user_id']
-        completion_status = request.args['completion_status']
         quests = {}
 
         try:
+            completion_status = request.args['completion_status']
             user = User.query.filter_by(id=user_id).one()
             user_quests = user.user_quests.filter_by(completion_status=completion_status).all()
             for user_quest in user_quests:
@@ -63,6 +63,9 @@ class UserQuestsResource(Resource):
 
         except NoResultFound:
             return abort(404)
+
+        except BadRequestKeyError:
+            return abort()
 
         user_quest_payload = _user_quest_payload(quests)
         # user_quest_payload['success'] = True

--- a/api/resources/user_quests.py
+++ b/api/resources/user_quests.py
@@ -3,7 +3,7 @@ import json
 from flask import jsonify
 
 import bleach
-import jsons
+# import jsons
 from flask import request
 from flask_restful import Resource, abort, reqparse, fields, marshal_with
 from sqlalchemy.orm.exc import NoResultFound

--- a/api/resources/user_quests.py
+++ b/api/resources/user_quests.py
@@ -3,6 +3,7 @@ import json
 from flask import jsonify
 
 import bleach
+import jsons
 from flask import request
 from flask_restful import Resource, abort, reqparse, fields, marshal_with
 from sqlalchemy.orm.exc import NoResultFound
@@ -16,13 +17,26 @@ from api.database.models import UserQuest
 #     map(json.dumps, quests)
 
 def _user_quest_payload(quests):
+    quest_objects = {}
+    for progress, quest in quests.items():
+        # breakpoint()
+        quest_objects[f"quest_id_{quest.id}"] = {
+            'id': quest.id,
+            'type': quest.type,
+            'name': quest.name,
+            'xp': quest.xp,
+            'encounter_req': quest.encounter_req,
+            'level': quest.level,
+            'progress': int(progress)
+        }
+    # return {'data': quest_objects}
+    # breakpoint()
     return {
         'data': {
             'id': 'Null',
             'type': 'quests',
             'attributes': {
-                 "quests":
-                 map(json.loads(quests))
+                 "quests": [quest_objects]
             }
         }
     }
@@ -32,18 +46,24 @@ class UserQuestsResource(Resource):
     def get(self, *args, **kwargs):
         user_id = request.view_args['user_id']
         completion_status = request.args['completion_status']
-        quests = []
+        quests = {}
 
         try:
             user = User.query.filter_by(id=user_id).one()
             user_quests = user.user_quests.filter_by(completion_status=completion_status).all()
             for user_quest in user_quests:
+                progress = user_quest.progress
                 quest_id = user_quest.quest_id
-                quests.append(Quest.query.filter_by(id=quest_id).one())
+                # quests.append(Quest.query.filter_by(id=quest_id).one())
+                quests[str(progress)] = Quest.query.filter_by(id=quest_id).one()
+                # breakpoint()
+
+                # breakpoint()
+                # quests.append(Quest.query.filter_by(id=quest_id).one())
 
         except NoResultFound:
             return abort(404)
 
         user_quest_payload = _user_quest_payload(quests)
-        user_quest_payload['success'] = True
+        # user_quest_payload['success'] = True
         return user_quest_payload, 200

--- a/api/resources/user_quests.py
+++ b/api/resources/user_quests.py
@@ -1,0 +1,49 @@
+import datetime
+import json
+from flask import jsonify
+
+import bleach
+from flask import request
+from flask_restful import Resource, abort, reqparse, fields, marshal_with
+from sqlalchemy.orm.exc import NoResultFound
+
+from api import db
+from api.database.models import Quest
+from api.database.models import User
+from api.database.models import UserQuest
+
+# def _format_quests(quests):
+#     map(json.dumps, quests)
+
+def _user_quest_payload(quests):
+    return {
+        'data': {
+            'id': 'Null',
+            'type': 'quests',
+            'attributes': {
+                 "quests":
+                 map(json.loads(quests))
+            }
+        }
+    }
+
+class UserQuestsResource(Resource):
+
+    def get(self, *args, **kwargs):
+        user_id = request.view_args['user_id']
+        completion_status = request.args['completion_status']
+        quests = []
+
+        try:
+            user = User.query.filter_by(id=user_id).one()
+            user_quests = user.user_quests.filter_by(completion_status=completion_status).all()
+            for user_quest in user_quests:
+                quest_id = user_quest.quest_id
+                quests.append(Quest.query.filter_by(id=quest_id).one())
+
+        except NoResultFound:
+            return abort(404)
+
+        user_quest_payload = _user_quest_payload(quests)
+        user_quest_payload['success'] = True
+        return user_quest_payload, 200

--- a/api/resources/user_quests.py
+++ b/api/resources/user_quests.py
@@ -3,7 +3,6 @@ import json
 from flask import jsonify
 
 import bleach
-# import jsons
 from flask import request
 from flask_restful import Resource, abort, reqparse, fields, marshal_with
 from sqlalchemy.orm.exc import NoResultFound
@@ -13,13 +12,9 @@ from api.database.models import Quest
 from api.database.models import User
 from api.database.models import UserQuest
 
-# def _format_quests(quests):
-#     map(json.dumps, quests)
-
 def _user_quest_payload(quests):
     quest_objects = {}
     for progress, quest in quests.items():
-        # breakpoint()
         quest_objects[f"quest_id_{quest.id}"] = {
             'id': quest.id,
             'type': quest.type,
@@ -29,8 +24,7 @@ def _user_quest_payload(quests):
             'level': quest.level,
             'progress': int(progress)
         }
-    # return {'data': quest_objects}
-    # breakpoint()
+
     return {
         'data': {
             'id': 'Null',
@@ -54,12 +48,7 @@ class UserQuestsResource(Resource):
             for user_quest in user_quests:
                 progress = user_quest.progress
                 quest_id = user_quest.quest_id
-                # quests.append(Quest.query.filter_by(id=quest_id).one())
                 quests[str(progress)] = Quest.query.filter_by(id=quest_id).one()
-                # breakpoint()
-
-                # breakpoint()
-                # quests.append(Quest.query.filter_by(id=quest_id).one())
 
         except NoResultFound:
             return abort(404)
@@ -68,5 +57,4 @@ class UserQuestsResource(Resource):
             return abort()
 
         user_quest_payload = _user_quest_payload(quests)
-        # user_quest_payload['success'] = True
         return user_quest_payload, 200

--- a/tests/endpoints/user_quests/test_get_quests_for_user.py
+++ b/tests/endpoints/user_quests/test_get_quests_for_user.py
@@ -98,3 +98,10 @@ class GetQuestsTest(unittest.TestCase):
         assert_payload_field_type_value(self, quest_data, 'type', str, self.quest_1.type)
         assert_payload_field_type_value(self, quest_data, 'xp', int, self.quest_1.xp)
         assert_payload_field_type_value(self, quest_data, 'level', int, self.quest_1.level)
+
+    def test_sad_path_get_quests_for_user_no_params(self):
+        response = self.client.get(f"/api/v1/users/{self.user_1.id}/quests", content_type='application/json')
+
+        self.assertEqual(500, response.status_code)
+
+        # Come back and add in error messaging later

--- a/tests/endpoints/user_quests/test_get_quests_for_user.py
+++ b/tests/endpoints/user_quests/test_get_quests_for_user.py
@@ -35,7 +35,7 @@ class GetQuestsTest(unittest.TestCase):
         db_drop_everything(db)
         self.app_context.pop()
 
-    def test_happy_path_get_quests_for_user(self):
+    def test_happy_path_get_quests_for_user_true(self):
         response = self.client.get(f'/api/v1/users/{self.user_1.id}/quests?completion_status=true', content_type='application/json')
 
         self.assertEqual(200, response.status_code)
@@ -66,3 +66,35 @@ class GetQuestsTest(unittest.TestCase):
         assert_payload_field_type_value(self, quest_data, 'type', str, self.quest_2.type)
         assert_payload_field_type_value(self, quest_data, 'xp', int, self.quest_2.xp)
         assert_payload_field_type_value(self, quest_data, 'level', int, self.quest_2.level)
+
+    def test_happy_path_get_quests_for_user_false(self):
+        response = self.client.get(f'/api/v1/users/{self.user_1.id}/quests?completion_status=false', content_type='application/json')
+
+        self.assertEqual(200, response.status_code)
+
+        data = json.loads(response.data.decode('utf-8'))
+
+        assert_payload_field_type(self, data, 'data', dict)
+
+        all_quest_data = data['data']
+
+        assert_payload_field_type_value(self, all_quest_data, 'id', str, 'Null')
+        assert_payload_field_type_value(self, all_quest_data, 'type', str, 'quests')
+
+        attributes = all_quest_data['attributes']
+
+        assert_payload_field_type(self, attributes, 'quests', list)
+
+        quest = attributes['quests'][0]
+
+        assert_payload_field_type(self, quest, 'quest_id_1', dict)
+
+        quest_data = quest['quest_id_1']
+
+        assert_payload_field_type_value(self, quest_data, 'encounter_req', int, self.quest_1.encounter_req)
+        assert_payload_field_type_value(self, quest_data, 'id', int, self.quest_1.id)
+        assert_payload_field_type_value(self, quest_data, 'name', str, self.quest_1.name)
+        assert_payload_field_type_value(self, quest_data, 'progress', int, self.user_quest_1.progress)
+        assert_payload_field_type_value(self, quest_data, 'type', str, self.quest_1.type)
+        assert_payload_field_type_value(self, quest_data, 'xp', int, self.quest_1.xp)
+        assert_payload_field_type_value(self, quest_data, 'level', int, self.quest_1.level)

--- a/tests/endpoints/user_quests/test_get_quests_for_user.py
+++ b/tests/endpoints/user_quests/test_get_quests_for_user.py
@@ -1,0 +1,68 @@
+import json
+import unittest
+from unittest.mock import patch
+from copy import deepcopy
+from api import create_app, db
+from api.database.models import UserQuest, User, Quest
+from tests import db_drop_everything, assert_payload_field_type_value, \
+    assert_payload_field_type
+
+class GetQuestsTest(unittest.TestCase):
+    def setUp(self):
+        self.app = create_app('testing')
+        self.app_context = self.app.app_context()
+        self.app_context.push()
+        db.create_all()
+        self.client = self.app.test_client()
+
+        self.user_1 = User(username='George', email="george@example.com", xp=1000000000)
+        self.user_1.insert()
+        self.quest_1 = Quest(name="Make'a da pancake!", xp=5, level=1, encounter_req=3, type='active')
+        self.quest_2 = Quest(name="Make'a da biscuit!", xp=10, level=2, encounter_req=3, type='active')
+        db.session.add(self.quest_1)
+        db.session.commit()
+        db.session.add(self.quest_2)
+        db.session.commit()
+        self.user_quest_1 = UserQuest(quest_id=self.quest_1.id, user_id=self.user_1.id, progress=1, completion_status=False)
+        self.user_quest_2 = UserQuest(quest_id=self.quest_2.id, user_id=self.user_1.id, progress=1, completion_status=True)
+        db.session.add(self.user_quest_1)
+        db.session.commit()
+        db.session.add(self.user_quest_2)
+        db.session.commit()
+
+    def tearDown(self):
+        db.session.remove()
+        db_drop_everything(db)
+        self.app_context.pop()
+
+    def test_happy_path_get_quests_for_user(self):
+        response = self.client.get(f'/api/v1/users/{self.user_1.id}/quests?completion_status=true', content_type='application/json')
+
+        self.assertEqual(200, response.status_code)
+
+        data = json.loads(response.data.decode('utf-8'))
+
+        assert_payload_field_type(self, data, 'data', dict)
+
+        all_quest_data = data['data']
+
+        assert_payload_field_type_value(self, all_quest_data, 'id', str, 'Null')
+        assert_payload_field_type_value(self, all_quest_data, 'type', str, 'quests')
+
+        attributes = all_quest_data['attributes']
+
+        assert_payload_field_type(self, attributes, 'quests', list)
+
+        quest = attributes['quests'][0]
+
+        assert_payload_field_type(self, quest, 'quest_id_2', dict)
+
+        quest_data = quest['quest_id_2']
+
+        assert_payload_field_type_value(self, quest_data, 'encounter_req', int, self.quest_2.encounter_req)
+        assert_payload_field_type_value(self, quest_data, 'id', int, self.quest_2.id)
+        assert_payload_field_type_value(self, quest_data, 'name', str, self.quest_2.name)
+        assert_payload_field_type_value(self, quest_data, 'progress', int, self.user_quest_2.progress)
+        assert_payload_field_type_value(self, quest_data, 'type', str, self.quest_2.type)
+        assert_payload_field_type_value(self, quest_data, 'xp', int, self.quest_2.xp)
+        assert_payload_field_type_value(self, quest_data, 'level', int, self.quest_2.level)


### PR DESCRIPTION
### Description

Adds the `users/:id/quests` endpoint, allowing the front end to fetch a user's quest data filtered by completion status. The format of the endpoint and request have been updated and can be seen below:

![Baller screenshot of the endpoint in postman](https://user-images.githubusercontent.com/60277914/109078678-f74dd580-76ba-11eb-93ee-dc773e9a330a.png)

### Closes issue(s)
Closes #13  
Closes #15 
### Testing
Tests were added for happy and sad path, and are passing.
### Screenshots

### Changes include
- [ ] Bugfix (non-breaking change that solves an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

### Checklist
- [X] I have written tests for this code (happy & sad)
- [ ] I have updated the Readme
- [X] I ran full test suite - all tests passing

### Other comments
YEET