### PR TITLE
Patch user quest endpoint

### DIFF
--- a/tests/endpoints/user_quests/test_patch_quests_for_user.py
+++ b/tests/endpoints/user_quests/test_patch_quests_for_user.py
@@ -82,3 +82,11 @@ class PatchQuestsTest(unittest.TestCase):
 				assert_payload_field_type_value(self, attributes, 'response', str, 'successful')
 				assert_payload_field_type_value(self, attributes, 'progress', int, int(payload2['progress']))
 				assert_payload_field_type_value(self, attributes, 'completion_status', bool, True)
+
+		def test_sad_path_get_quests_for_user_no_params(self):
+				response = self.client.patch(f"/api/v1/users/{self.user_1.id}/quests", content_type='application/json')
+
+				self.assertEqual(400, response.status_code)
+
+				# Come back and add in error messaging later
+		

--- a/tests/endpoints/user_quests/test_patch_quests_for_user.py
+++ b/tests/endpoints/user_quests/test_patch_quests_for_user.py
@@ -1,0 +1,46 @@
+import json
+import unittest
+from unittest.mock import patch
+from copy import deepcopy
+from api import create_app, db
+from api.database.models import UserQuest, User, Quest
+from tests import db_drop_everything, assert_payload_field_type_value, \
+		assert_payload_field_type
+
+class PatchQuestsTest(unittest.TestCase):
+		def setUp(self):
+				self.app = create_app('testing')
+				self.app_context = self.app.app_context()
+				self.app_context.push()
+				db.create_all()
+				self.client = self.app.test_client()
+
+				self.user_1 = User(username='George', email="george@example.com", xp=1000000000)
+				self.user_1.insert()
+				self.quest_1 = Quest(name="Make'a da pancake!", xp=5, level=1, encounter_req=3, type='active')
+				self.quest_2 = Quest(name="Make'a da biscuit!", xp=10, level=2, encounter_req=3, type='active')
+				db.session.add(self.quest_1)
+				db.session.commit()
+				db.session.add(self.quest_2)
+				db.session.commit()
+				self.user_quest_1 = UserQuest(quest_id=self.quest_1.id, user_id=self.user_1.id, progress=1, completion_status=False)
+				self.user_quest_2 = UserQuest(quest_id=self.quest_2.id, user_id=self.user_1.id, progress=3, completion_status=False)
+				db.session.add(self.user_quest_1)
+				db.session.commit()
+				db.session.add(self.user_quest_2)
+				db.session.commit()
+				self.payload = {
+								'quest_id': str(self.quest_1.id), 
+								'progress': str(2)
+				}
+
+		def tearDown(self):
+				db.session.remove()
+				db_drop_everything(db)
+				self.app_context.pop()
+
+		def test_happy_path_user_quest_progress_can_be_patched(self):
+				payload = deepcopy(self.payload)
+				response = self.client.patch(f'/api/v1/users/{self.user_1.id}/quests', json=payload, content_type='application/json')
+
+				self.assertEqual(201, response.status_code)

--- a/tests/endpoints/user_quests/test_patch_quests_for_user.py
+++ b/tests/endpoints/user_quests/test_patch_quests_for_user.py
@@ -18,19 +18,23 @@ class PatchQuestsTest(unittest.TestCase):
 				self.user_1 = User(username='George', email="george@example.com", xp=1000000000)
 				self.user_1.insert()
 				self.quest_1 = Quest(name="Make'a da pancake!", xp=5, level=1, encounter_req=3, type='active')
-				self.quest_2 = Quest(name="Make'a da biscuit!", xp=10, level=2, encounter_req=3, type='active')
+				self.quest_2 = Quest(name="Make'a da biscuit!", xp=10, level=2, encounter_req=1, type='active')
 				db.session.add(self.quest_1)
 				db.session.commit()
 				db.session.add(self.quest_2)
 				db.session.commit()
 				self.user_quest_1 = UserQuest(quest_id=self.quest_1.id, user_id=self.user_1.id, progress=1, completion_status=False)
-				self.user_quest_2 = UserQuest(quest_id=self.quest_2.id, user_id=self.user_1.id, progress=3, completion_status=False)
+				self.user_quest_2 = UserQuest(quest_id=self.quest_2.id, user_id=self.user_1.id, progress=1, completion_status=False)
 				db.session.add(self.user_quest_1)
 				db.session.commit()
 				db.session.add(self.user_quest_2)
 				db.session.commit()
 				self.payload = {
 								'quest_id': str(self.quest_1.id), 
+								'progress': str(2)
+				}
+				self.payload2 = {
+								'quest_id': str(self.quest_2.id), 
 								'progress': str(2)
 				}
 
@@ -58,3 +62,23 @@ class PatchQuestsTest(unittest.TestCase):
 				assert_payload_field_type_value(self, attributes, 'response', str, 'successful')
 				assert_payload_field_type_value(self, attributes, 'progress', int, int(payload['progress']))
 				assert_payload_field_type_value(self, attributes, 'completion_status', bool, False)
+				
+		def test_happy_path_progress_change_can_update_completion_status(self):
+				payload2 = deepcopy(self.payload2)
+				response = self.client.patch(f'/api/v1/users/{self.user_1.id}/quests', json=payload2, content_type='application/json')
+
+				self.assertEqual(201, response.status_code)
+				data = json.loads(response.data.decode('utf-8'))
+				assert_payload_field_type(self, data, 'data', dict)
+
+				all_user_quest_data = data['data']
+
+				assert_payload_field_type_value(self, all_user_quest_data, 'id', int, self.user_quest_2.id)
+				assert_payload_field_type_value(self, all_user_quest_data, 'type', str, 'user_quests')
+				assert_payload_field_type(self, all_user_quest_data, 'attributes', dict)
+				
+				attributes = all_user_quest_data['attributes']
+
+				assert_payload_field_type_value(self, attributes, 'response', str, 'successful')
+				assert_payload_field_type_value(self, attributes, 'progress', int, int(payload2['progress']))
+				assert_payload_field_type_value(self, attributes, 'completion_status', bool, True)

--- a/tests/endpoints/user_quests/test_patch_quests_for_user.py
+++ b/tests/endpoints/user_quests/test_patch_quests_for_user.py
@@ -44,3 +44,17 @@ class PatchQuestsTest(unittest.TestCase):
 				response = self.client.patch(f'/api/v1/users/{self.user_1.id}/quests', json=payload, content_type='application/json')
 
 				self.assertEqual(201, response.status_code)
+				data = json.loads(response.data.decode('utf-8'))
+				assert_payload_field_type(self, data, 'data', dict)
+
+				all_user_quest_data = data['data']
+
+				assert_payload_field_type_value(self, all_user_quest_data, 'id', int, self.user_quest_1.id)
+				assert_payload_field_type_value(self, all_user_quest_data, 'type', str, 'user_quests')
+				assert_payload_field_type(self, all_user_quest_data, 'attributes', dict)
+				
+				attributes = all_user_quest_data['attributes']
+
+				assert_payload_field_type_value(self, attributes, 'response', str, 'successful')
+				assert_payload_field_type_value(self, attributes, 'progress', int, int(payload['progress']))
+				assert_payload_field_type_value(self, attributes, 'completion_status', bool, False)


### PR DESCRIPTION
### Description
Add endpoint to patch user request progress and update completion status if applicable

### Closes issue(s)
Closes #14 

### Testing
- Happy path to update user_quest progress
- Happy path to update user_quest completions_status
- Sad path for no user params

### Screenshots
![Screen Shot 2021-02-24 at 6 31 44 PM](https://user-images.githubusercontent.com/60531761/109089533-a9db6380-76ce-11eb-9d88-f7c39cf224b0.png)

### Changes include
- [ ] Bugfix (non-breaking change that solves an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

### Checklist
- [X] I have written tests for this code (happy & sad)
- [ ] I have updated the Readme
- [X] I ran full test suite - all tests passing

### Other comments
