### PR TITLE
Change HTTP verb for Users endpoint to POST

### DIFF
--- a/api/resources/users.py
+++ b/api/resources/users.py
@@ -44,7 +44,7 @@ class UserResource(Resource):
     this Resource file is for our /users endpoints which don't require
     a resource ID in the URI path
     """
-    def get(self, *args, **kwargs):
+    def post(self, *args, **kwargs):
         data = request.get_json()
         user_email = data['email']
         try:

--- a/tests/endpoints/users/test_get_user_by_email.py
+++ b/tests/endpoints/users/test_get_user_by_email.py
@@ -31,7 +31,7 @@ class GetUserTest(unittest.TestCase):
 
     def test_happypath_get_a_user_by_email(self):
         payload = deepcopy(self.payload)
-        response = self.client.get(
+        response = self.client.post(
                     '/api/v1/users', json=payload,
                     content_type='application/json'
                 )
@@ -69,7 +69,7 @@ class GetUserTest(unittest.TestCase):
 
     def test_endpoint_sadpath_bad_email_user(self):
         payload = {'email': 'bademail'}
-        response = self.client.get(
+        response = self.client.post(
                 '/api/v1/users', json=payload,
                 content_type='application/json'
             )


### PR DESCRIPTION
Co-authored-by: Shaunda Cunningham <4582791+smcunning@users.noreply.github.com>
Co-authored-by: George Soderholm <62966396+GeorgieGirl24@users.noreply.github.com>
Co-authored-by: Carson Jardine <65981543+carson-jardine@users.noreply.github.com>
Co-authored-by: Jake Heft <60531761+jakeheft@users.noreply.github.com>

### Description
Front end cannot send GET requests with a body, so we are changing the Users endpoint to use a POST verb.
### Closes issue(s)

### Testing
Changed previous endpoint request tests to use POST.
### Screenshots

### Changes include
- [X] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

### Checklist
- [X] I have written tests for this code (happy & sad)
- [ ] I have updated the Readme
- [X] I ran full test suite - all tests passing

### Other comments
