### PR TITLE
Get quest encounters by progress

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@
 ### PATCH `/api/v1/users/1/quests`
 <img width="1017" alt="Screen Shot 2021-02-25 at 11 03 46 AM" src="https://user-images.githubusercontent.com/62966396/109201856-8ca2a580-775f-11eb-8b6f-eb59eb5e76c4.png">
 
+
+### GET `/api/v1/quests/1/encounters?progress=1`
+<img width="1017" alt="Screen Shot 2021-02-25 at 8 10 28 PM" src="https://user-images.githubusercontent.com/60531761/109249226-8682e800-77a4-11eb-8f06-07f48e5a0d22.png">
+
 ## Schema
 
 ![Screen Shot 2021-02-25 at 10 51 19 AM](https://user-images.githubusercontent.com/62966396/109195377-ac35d000-7757-11eb-9753-31148d771b35.png)

--- a/api/__init__.py
+++ b/api/__init__.py
@@ -79,8 +79,10 @@ def create_app(config_name='default'):
 
     from api.resources.users import UserResource
     from api.resources.user_quests import UserQuestsResource
+    from api.resources.quests import QuestResource
 
     api.add_resource(UserResource, '/api/v1/users')
     api.add_resource(UserQuestsResource, '/api/v1/users/<int:user_id>/quests')
+    api.add_resource(QuestResource, '/api/v1/quests/<int:quest_id>/encounters')
 
     return app

--- a/api/database/models.py
+++ b/api/database/models.py
@@ -92,6 +92,7 @@ class Quest(db.Model):
     updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
     # relationships
     user_quests = db.relationship('UserQuest', backref='user_quest', lazy='dynamic')
+    encounters = db.relationship('Encounter', backref='encounters', lazy='dynamic')
 
     def __init__(self, name, xp, encounter_req, type, level):
         if name is not None:

--- a/api/resources/quests.py
+++ b/api/resources/quests.py
@@ -46,9 +46,9 @@ class QuestResource(Resource):
             progress = request.args['progress']
             quest = Quest.query.filter_by(id=quest_id).one()
             encounter = quest.encounters.filter_by(progress=progress).one()
-            # breakpoint()
-        except Exception:
-            abort()
+
+        except NoResultFound:
+            return abort(404)
 
         quest_encounters_payload = _quest_encounters_payload(encounter)
         return quest_encounters_payload, 200

--- a/api/resources/quests.py
+++ b/api/resources/quests.py
@@ -1,0 +1,26 @@
+import datetime
+import json
+from flask import jsonify
+
+import bleach
+from flask import request
+from flask_restful import Resource, abort, reqparse, fields, marshal_with
+from sqlalchemy.orm.exc import NoResultFound
+
+from api import db
+from api.database.models import Quest
+from api.database.models import User
+from api.database.models import UserQuest
+from api.database.models import Encounter
+from api.database.models import Action
+
+def _quest_payload(quest):
+
+class QuestResource(Resource):
+    def get(self, *args, **kwargs):
+        quest_id = request.view_args['id']
+        quest = {}
+
+        try:
+            progress = request.args['progress']
+            quest = Quest.query.filter_by(id=quest_id).one()

--- a/api/resources/quests.py
+++ b/api/resources/quests.py
@@ -17,7 +17,7 @@ from api.database.models import Action
 def _quest_encounters_payload(encounter):
     return {
         'data': {
-            'id': None,
+            'id': encounter.id,
             'type': 'encounters',
             'attributes': {
                 'progress': encounter.progress,

--- a/api/resources/quests.py
+++ b/api/resources/quests.py
@@ -14,13 +14,41 @@ from api.database.models import UserQuest
 from api.database.models import Encounter
 from api.database.models import Action
 
-def _quest_payload(quest):
+def _quest_encounters_payload(encounter):
+    return {
+        'data': {
+            'id': None,
+            'type': 'encounters',
+            'attributes': {
+                'progress': encounter.progress,
+                'monster_image': encounter.monster_image,
+                'actions': _serial_actions(encounter.actions)
+            }
+        }
+    }
+
+def _serial_actions(actions):
+    serial_actions = []
+
+    for action in actions:
+        serial_actions.append({
+            'id': action.id,
+            'description': action.description
+        })
+
+    return serial_actions
 
 class QuestResource(Resource):
     def get(self, *args, **kwargs):
-        quest_id = request.view_args['id']
+        quest_id = request.view_args['quest_id']
         quest = {}
-
         try:
             progress = request.args['progress']
             quest = Quest.query.filter_by(id=quest_id).one()
+            encounter = quest.encounters.filter_by(progress=progress).one()
+            # breakpoint()
+        except Exception:
+            abort()
+
+        quest_encounters_payload = _quest_encounters_payload(encounter)
+        return quest_encounters_payload, 200

--- a/api/resources/user_quests.py
+++ b/api/resources/user_quests.py
@@ -87,7 +87,7 @@ class UserQuestsResource(Resource):
                 user_quest.completion_status = True
                 db.session.add(user_quest)
                 db.session.commit()
-            
+
 
         except NoResultFound:
             return abort(404)

--- a/tests/endpoints/quests/test_get_encounters_by_quest.py
+++ b/tests/endpoints/quests/test_get_encounters_by_quest.py
@@ -3,7 +3,7 @@ import unittest
 from unittest.mock import patch
 from copy import deepcopy
 from api import create_app, db
-from api.database.models import UserQuest, User, Quest
+from api.database.models import UserQuest, User, Quest, Encounter, Action
 from tests import db_drop_everything, assert_payload_field_type_value, \
     assert_payload_field_type
 
@@ -15,7 +15,7 @@ class GetEncountersByQuest(unittest.TestCase):
         db.create_all()
         self.client = self.app.test_client()
 
-        self.user_1 = User(username='George', email="george@example.com", xp=1000000000)
+        self.user_1 = User(username='Steve', email="steve@example.com", xp=1000000000)
         self.user_1.insert()
         self.quest_1 = Quest(name="Make'a da pancake!", xp=5, level=1, encounter_req=3, type='active')
         self.quest_2 = Quest(name="Make'a da biscuit!", xp=10, level=2, encounter_req=3, type='active')

--- a/tests/endpoints/quests/test_get_encounters_by_quest.py
+++ b/tests/endpoints/quests/test_get_encounters_by_quest.py
@@ -1,0 +1,55 @@
+import json
+import unittest
+from unittest.mock import patch
+from copy import deepcopy
+from api import create_app, db
+from api.database.models import UserQuest, User, Quest
+from tests import db_drop_everything, assert_payload_field_type_value, \
+    assert_payload_field_type
+
+class GetEncountersByQuest(unittest.TestCase):
+    def setUp(self):
+        self.app = create_app('testing')
+        self.app_context = self.app.app_context()
+        self.app_context.push()
+        db.create_all()
+        self.client = self.app.test_client()
+
+        self.user_1 = User(username='George', email="george@example.com", xp=1000000000)
+        self.user_1.insert()
+        self.quest_1 = Quest(name="Make'a da pancake!", xp=5, level=1, encounter_req=3, type='active')
+        self.quest_2 = Quest(name="Make'a da biscuit!", xp=10, level=2, encounter_req=3, type='active')
+        db.session.add(self.quest_1)
+        db.session.commit()
+        db.session.add(self.quest_2)
+        db.session.commit()
+        self.user_quest_1 = UserQuest(quest_id=self.quest_1.id, user_id=self.user_1.id, progress=1, completion_status=False)
+        self.user_quest_2 = UserQuest(quest_id=self.quest_2.id, user_id=self.user_1.id, progress=1, completion_status=True)
+        db.session.add(self.user_quest_1)
+        db.session.commit()
+        db.session.add(self.user_quest_2)
+        db.session.commit()
+        self.encounter_1 = Encounter(monster_image='https://images.huffingtonpost.com/2015-02-05-trollersTroll-thumb.jpg', quest_id=self.quest_1.id, progress=1)
+        db.session.add(self.encounter_1)
+        db.session.commit()
+        self.encounter_2 = Encounter(monster_image='https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSdIfSV09BWeNuPejZM4txwTFJJKikYV_WMLg&usqp=CAU', quest_id=self.quest_1.id, progress=2)
+        db.session.add(self.encounter_2)
+        db.session.commit()
+        self.action_1 = Action(encounter_id=self.encounter_1.id,  description='Send a message to a recruiter')
+        db.session.add(self.action_1)
+        db.session.commit()
+        self.action_2 = Action(encounter_id=self.encounter_1.id, description='Apply to a Job')
+        db.session.add(self.action_2)
+        db.session.commit()
+        self.action_3 = Action(encounter_id=self.encounter_2.id, description='Schedule a coffee meetup with a target Company')
+        db.session.add(self.action_3)
+        db.session.commit()
+
+    def tearDown(self):
+        db.session.remove()
+        db_drop_everything(db)
+        self.app_context.pop()
+
+    def test_happy_path_get_encounters_for_quest_by_progress(self):
+        response = self.client.get(f'/api/v1/quests/{self.quest_1.id}/encounters?progress=2', content_type='application/json')
+        breakpoint()

--- a/tests/endpoints/quests/test_get_encounters_by_quest.py
+++ b/tests/endpoints/quests/test_get_encounters_by_quest.py
@@ -52,4 +52,18 @@ class GetEncountersByQuest(unittest.TestCase):
 
     def test_happy_path_get_encounters_for_quest_by_progress(self):
         response = self.client.get(f'/api/v1/quests/{self.quest_1.id}/encounters?progress=2', content_type='application/json')
-        breakpoint()
+        self.assertEqual(200, response.status_code)
+        data = json.loads(response.data.decode('utf-8'))
+        assert_payload_field_type(self, data, 'data', dict)
+        encounter_data = data['data']
+        assert_payload_field_type_value(self, encounter_data, 'id', int, self.encounter_2.id)
+        assert_payload_field_type_value(self, encounter_data, 'type', str, 'encounters')
+        attributes = encounter_data['attributes']
+        assert_payload_field_type(self, encounter_data, 'attributes', dict)
+        assert_payload_field_type_value(self, attributes, 'progress', int, self.encounter_2.progress)
+        assert_payload_field_type_value(self, attributes, 'monster_image', str, self.encounter_2.monster_image)
+        assert_payload_field_type(self, attributes, 'actions', list)
+        actions = attributes['actions']
+        assert_payload_field_type_value(self, actions[0], 'id', int, self.action_3.id)
+        assert_payload_field_type_value(self, actions[0], 'description', str, self.action_3.description)
+        

--- a/tests/endpoints/quests/test_get_encounters_by_quest.py
+++ b/tests/endpoints/quests/test_get_encounters_by_quest.py
@@ -66,4 +66,12 @@ class GetEncountersByQuest(unittest.TestCase):
         actions = attributes['actions']
         assert_payload_field_type_value(self, actions[0], 'id', int, self.action_3.id)
         assert_payload_field_type_value(self, actions[0], 'description', str, self.action_3.description)
-        
+
+    def test_sad_path_get_encounters_for_quest_when_no_progress_given(self):
+        response = self.client.get(f'/api/v1/quests/{self.quest_1.id}/encounters?progress=', content_type='application/json')
+        self.assertEqual(500, response.status_code)
+
+    def test_sad_path_get_encounters_for_quest_when_wrong_progress_given(self):
+        response = self.client.get(
+            f'/api/v1/quests/{self.quest_1.id}/encounters?progress=896', content_type='application/json')
+        self.assertEqual(404, response.status_code)


### PR DESCRIPTION
### Description
Add endpoint to get encounter with progress

### Closes issue(s)
Closes #16 

### Testing
- Happy path testing for getting encounter with valid progress
- Sad path testing for getting encounter with invalid progress

### Screenshots
![Screen Shot 2021-02-25 at 8 01 58 PM](https://user-images.githubusercontent.com/60531761/109249226-8682e800-77a4-11eb-8f06-07f48e5a0d22.png)

### Changes include
- [ ] Bugfix (non-breaking change that solves an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

### Checklist
- [X] I have written tests for this code (happy & sad)
- [X] I have updated the Readme
- [X] I ran full test suite - all tests passing

### Other comments
