### PR TITLE
Revise get user quests

### DIFF
--- a/api/resources/user_quests.py
+++ b/api/resources/user_quests.py
@@ -58,6 +58,17 @@ class UserQuestsResource(Resource):
             completion_status = request.args['completion_status']
             user = User.query.filter_by(id=user_id).one()
             user_quests = user.user_quests.filter_by(completion_status=completion_status).all()
+
+            if user_quests.__len__() == 0:
+                one = UserQuest(quest_id=1, user_id=user.id, completion_status=False, progress=1)
+                two = UserQuest(quest_id=4, user_id=user.id, completion_status=False, progress=1)
+                three = UserQuest(quest_id=7, user_id=user.id, completion_status=False, progress=1)
+                db.session.add(one)
+                db.session.add(two)
+                db.session.add(three)
+                db.session.commit()
+                user_quests = user.user_quests.filter_by(completion_status=completion_status).all()
+
             for user_quest in user_quests:
                 progress = user_quest.progress
                 quest_id = user_quest.quest_id

--- a/manage.py
+++ b/manage.py
@@ -39,6 +39,10 @@ def db_seed():
     catch_troll = Quest(name='Catch a Troll for the Town Wizard', xp=200, encounter_req=1, type='active', level=1)
     root_bandit = Quest(name='Root out the Craghook Bandits', xp=500, encounter_req=3, type='active', level=2)
     slay_dragon = Quest(name='Slay Argoroth the Dragon', xp=1000, encounter_req=5, type='active', level=3)
+    quest_4 = Quest(name='quest4', xp=100, encounter_req=1, type='passive', level=1)
+    quest_5 = Quest(name='quest5', xp=500, encounter_req=3, type='passive', level=2)
+    quest_6 = Quest(name='quest6', xp=1000, encounter_req=5, type='passive', level=3)
+    kill_the_wildabeast = Quest(name="Kill the Wildabeast", xp=200, encounter_req=1, type='supportive', level=1)
     #
     # # user_quests
     user_quest_1 = UserQuest(quest_id=1, user_id=1, completion_status=False, progress=1)
@@ -49,11 +53,15 @@ def db_seed():
     set_troll_bait = Encounter(monster_image='https://images.huffingtonpost.com/2015-02-05-trollersTroll-thumb.jpg', quest_id=1, progress=1)
     build_troll_trap = Encounter(monster_image='https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSdIfSV09BWeNuPejZM4txwTFJJKikYV_WMLg&usqp=CAU', quest_id=1, progress=1)
     knock_out = Encounter(monster_image='https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSdIfSV09BWeNuPejZM4txwTFJJKikYV_WMLg&usqp=CAU', quest_id=2, progress=1)
+    trap = Encounter(monster_image='https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSdIfSV09BWeNuPejZM4txwTFJJKikYV_WMLg&usqp=CAU', quest_id=7, progress=1)
+
     #
     # # actions
     leave_steak = Action(encounter_id=2,  description='Send a message to a recruiter')
     hit_troll_with_stick = Action(encounter_id=1, description='Apply to a Job')
     throw_granade = Action(encounter_id=3, description='Schedule a coffee meetup with a target Company')
+    punch = Action(encounter_id=4, description='Update your resume')
+    kick = Action(encounter_id=4, description='Go to networking event')
 
 
     db.session.add(ian)
@@ -68,6 +76,10 @@ def db_seed():
     db.session.add(catch_troll)
     db.session.add(root_bandit)
     db.session.add(slay_dragon)
+    db.session.add(quest_4)
+    db.session.add(quest_5)
+    db.session.add(quest_6)
+    db.session.add(kill_the_wildabeast)
     #
     db.session.add(user_quest_1)
     db.session.add(user_quest_2)
@@ -76,10 +88,13 @@ def db_seed():
     db.session.add(set_troll_bait)
     db.session.add(build_troll_trap)
     db.session.add(knock_out)
+    db.session.add(trap)
 
     db.session.add(leave_steak)
     db.session.add(hit_troll_with_stick)
     db.session.add(throw_granade)
+    db.session.add(punch)
+    db.session.add(kick)
 
     db.session.commit()
     print(f'obj count: {len(db.session.query(User).all())}')

--- a/tests/endpoints/user_quests/test_get_quests_for_user.py
+++ b/tests/endpoints/user_quests/test_get_quests_for_user.py
@@ -19,10 +19,22 @@ class GetQuestsTest(unittest.TestCase):
         self.user_1.insert()
         self.quest_1 = Quest(name="Make'a da pancake!", xp=5, level=1, encounter_req=3, type='active')
         self.quest_2 = Quest(name="Make'a da biscuit!", xp=10, level=2, encounter_req=3, type='active')
+        self.quest_3 = Quest(name="Make'a da nuggets!", xp=10, level=2, encounter_req=3, type='active')
+        self.quest_4 = Quest(name="Make'a da cupcake!", xp=10, level=2, encounter_req=3, type='passive')
+        self.quest_5 = Quest(name="Make'a da pizza!", xp=10, level=2, encounter_req=3, type='passive')
+        self.quest_6 = Quest(name="Make'a da bacon!", xp=10, level=2, encounter_req=3, type='passive')
+        self.quest_7 = Quest(name="Make'a da pie!", xp=10, level=2, encounter_req=3, type='supportive')
         db.session.add(self.quest_1)
         db.session.commit()
         db.session.add(self.quest_2)
         db.session.commit()
+        db.session.add(self.quest_3)
+        db.session.add(self.quest_4)
+        db.session.add(self.quest_5)
+        db.session.add(self.quest_6)
+        db.session.add(self.quest_7)
+        db.session.commit()
+
         self.user_quest_1 = UserQuest(quest_id=self.quest_1.id, user_id=self.user_1.id, progress=1, completion_status=False)
         self.user_quest_2 = UserQuest(quest_id=self.quest_2.id, user_id=self.user_1.id, progress=1, completion_status=True)
         db.session.add(self.user_quest_1)
@@ -108,7 +120,11 @@ class GetQuestsTest(unittest.TestCase):
 
     def test_for_user_without_user_quests(self):
         new_user = User(username='Billy', email="billy@example.com", xp=0)
+        db.session.add(new_user)
+        db.session.commit()
+
         user_quests = new_user.user_quests.all().__len__()
+
         self.assertEqual(0, user_quests)
 
         response = self.client.get(f'/api/v1/users/{new_user.id}/quests?completion_status=false', content_type='application/json')

--- a/tests/endpoints/user_quests/test_get_quests_for_user.py
+++ b/tests/endpoints/user_quests/test_get_quests_for_user.py
@@ -105,3 +105,14 @@ class GetQuestsTest(unittest.TestCase):
         self.assertEqual(500, response.status_code)
 
         # Come back and add in error messaging later
+
+    def test_for_user_without_user_quests(self):
+        new_user = User(username='Billy', email="billy@example.com", xp=0)
+        user_quests = new_user.user_quests.all().__len__()
+        self.assertEqual(0, user_quests)
+
+        response = self.client.get(f'/api/v1/users/{new_user.id}/quests?completion_status=false', content_type='application/json')
+
+        user_quests = new_user.user_quests.all().__len__()
+
+        self.assertEqual(3, user_quests)


### PR DESCRIPTION
### Description
Fixes issue when a user does not have any `user_quests`. When we GET for the first time for that user, we'll now generate the first three quests - one active, one passive, one supportive.

### Closes issue(s)
Closes #27 

### Testing
Tested for happy path

### Screenshots

### Changes include
- [X] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

### Checklist
- [X] I have written tests for this code (happy & sad)
- [ ] I have updated the Readme
- [X] I ran full test suite - all tests passing

### Other comments
