### PR TITLE
Fix quest creation logic in UserQuest GET action

### DIFF
--- a/api/resources/user_quests.py
+++ b/api/resources/user_quests.py
@@ -59,7 +59,7 @@ class UserQuestsResource(Resource):
             user = User.query.filter_by(id=user_id).one()
             user_quests = user.user_quests.filter_by(completion_status=completion_status).all()
 
-            if user_quests.__len__() == 0:
+            if user.user_quests.all().__len__() == 0:
                 one = UserQuest(quest_id=1, user_id=user.id, completion_status=False, progress=1)
                 two = UserQuest(quest_id=4, user_id=user.id, completion_status=False, progress=1)
                 three = UserQuest(quest_id=7, user_id=user.id, completion_status=False, progress=1)


### PR DESCRIPTION
Co-authored-by: Shaunda Cunningham <4582791+smcunning@users.noreply.github.com>
Co-authored-by: George Soderholm <62966396+GeorgieGirl24@users.noreply.github.com>
Co-authored-by: Carson Jardine <65981543+carson-jardine@users.noreply.github.com>
Co-authored-by: Jake Heft <60531761+jakeheft@users.noreply.github.com>

### Description
The initial `UserQuest` creation check in the `GET users/:id/quests` endpoint included the `completion_status` filter passed in the request. This meant that, if a user ONLY had 3 incomplete quests, but a request was made for that users completed quests, it would generate 3 new incomplete tests. This has been fixed by updating the conditional to look for all of a users quests.
### Closes issue(s)

### Testing

### Screenshots

### Changes include
- [X] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

### Checklist
- [ ] I have written tests for this code (happy & sad)
- [ ] I have updated the Readme
- [ ] I ran full test suite - all tests passing

### Other comments
